### PR TITLE
Use Javascript to create audio elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,16 +21,6 @@
     <div id="div-root" class="container">
         <img id="image-normal" class="container-image" src="public/images/1.png" />
         <img id="image-poke" class="container-image" src="public/images/2.png" />
-
-        <audio id="audio-music" loop volume="0.8">
-            <source src="public/sounds/music.ogg" type="audio/ogg">
-            <source src="public/sounds/music.mp3" type="audio/mpeg">
-        </audio>
-
-        <audio id="audio-poke">
-            <source src="public/sounds/poke.ogg" type="audio/ogg">
-            <source src="public/sounds/poke.mp3" type="audio/mpeg">
-        </audio>
     </div>
 
     <script type="application/javascript" src="public/scripts/counter.js"></script>

--- a/public/scripts/counter.js
+++ b/public/scripts/counter.js
@@ -5,12 +5,42 @@ var divRoot = document.getElementById('div-root');
 var imageNormal = document.getElementById('image-normal');
 var imagePoke = document.getElementById('image-poke');
 
-var audioMusic = document.getElementById('audio-music');
-var audioPoke = document.getElementById('audio-poke');
+var audioMusic = createAudioElement({
+    'audio/ogg': 'public/sounds/music.ogg',
+    'audio/mpeg': 'public/sounds/music.mp3'
+})
+audioMusic.loop = true;
+audioMusic.volume = 0.8;
 
-var snd_react = [new Audio('public/sounds/react1.ogg'), new Audio('public/sounds/react2.ogg')];
+var audioPoke = createAudioElement({
+    'audio/ogg': 'public/sounds/poke.ogg',
+    'audio/mpeg': 'public/sounds/poke.mp3'
+});
 
+var reactionFiles = [
+    'public/sounds/react1.ogg',
+    'public/sounds/react2.ogg'
+]
+
+var snd_react = reactionFiles.map(createAudioElement);
 var clicks = 0;
+
+function createAudioElement(source) {
+    var audioElement = document.createElement('audio');
+    if(typeof source === 'string') {
+        var sourceElement = document.createElement('source');
+        sourceElement.src = source;
+        audioElement.appendChild(sourceElement);
+    } else {
+        Object.keys(source).forEach(function (key) {
+            var sourceElement = document.createElement('source');
+            sourceElement.type = key;
+            sourceElement.src = source[key];
+            audioElement.appendChild(sourceElement);
+        });
+    }
+    return audioElement;
+}
 
 function toggleImage(down) {
     imageNormal.style.display = down ? 'none' : 'block';

--- a/public/scripts/counter.js
+++ b/public/scripts/counter.js
@@ -18,27 +18,27 @@ var audioPoke = createAudioElement({
 });
 
 var reactionFiles = [
-    'public/sounds/react1.ogg',
-    'public/sounds/react2.ogg'
+    {
+        'audio/ogg': 'public/sounds/react1.ogg',
+        'audio/mpeg': 'public/sounds/react1.mp3'
+    },
+    {
+        'audio/ogg': 'public/sounds/react2.ogg',
+        'audio/mpeg': 'public/sounds/react2.mp3'
+    }
 ]
 
-var snd_react = reactionFiles.map(createAudioElement);
+var audioReact = reactionFiles.map(createAudioElement);
 var clicks = 0;
 
 function createAudioElement(source) {
     var audioElement = document.createElement('audio');
-    if(typeof source === 'string') {
+    Object.keys(source).forEach(function(key) {
         var sourceElement = document.createElement('source');
-        sourceElement.src = source;
+        sourceElement.type = key;
+        sourceElement.src = source[key];
         audioElement.appendChild(sourceElement);
-    } else {
-        Object.keys(source).forEach(function (key) {
-            var sourceElement = document.createElement('source');
-            sourceElement.type = key;
-            sourceElement.src = source[key];
-            audioElement.appendChild(sourceElement);
-        });
-    }
+    });
     return audioElement;
 }
 
@@ -55,8 +55,8 @@ function pok(e) {
     toggleImage(true);
 
     if(++clicks % 6 === 0) {
-        var index = Math.floor(Math.random() * snd_react.length);
-        snd_react[index].play();
+        var index = Math.floor(Math.random() * audioReact.length);
+        audioReact[index].play();
     }
 }
 


### PR DESCRIPTION
As per the concerns raised in [comment](https://github.com/caguiclajmg/platelet-clicker/issues/4#issuecomment-428427596):
> Partially fixed by [f741b03](https://github.com/caguiclajmg/platelet-clicker/commit/f741b036c7a2163294f07277124295382936251c), didn't move the reactions into `<audio>` tags as it could easily get ugly if a lot of reactions are added; in that case loading the audio via a loop in js would be a cleaner solution.

This is a proposed way of dealing with multiple reaction audios. The idea behind this commit is to create audio elements via Javascript but avoid inserting them into the DOM and hard-coding audio elements in HTML.